### PR TITLE
Grab issuer from config

### DIFF
--- a/lib/omniauth/strategies/okta.rb
+++ b/lib/omniauth/strategies/okta.rb
@@ -86,7 +86,7 @@ module OmniAuth
         site                 = client_options.fetch(:site)
         authorization_server = client_options.fetch(:authorization_server, 'default')
 
-        "#{site}/oauth2/#{authorization_server}"
+        "#{site}#{authorization_server}"
       end
 
       # Specifies the audience for the authorization server

--- a/lib/omniauth/strategies/okta.rb
+++ b/lib/omniauth/strategies/okta.rb
@@ -82,11 +82,10 @@ module OmniAuth
       # Okta provides a default, by default.
       #
       # @return [String]
-      def authorization_server_path
+      def authorization_server_issuer
         site                 = client_options.fetch(:site)
         authorization_server = client_options.fetch(:authorization_server, 'default')
-
-        "#{site}#{authorization_server}"
+        client_options.fetch(:issuer, "#{site}/oauth2/#{authorization_server}")
       end
 
       # Specifies the audience for the authorization server
@@ -105,7 +104,7 @@ module OmniAuth
                    false,
                    verify_iss:        true,
                    verify_aud:        true,
-                   iss:               authorization_server_path,
+                   iss:               authorization_server_issuer,
                    aud:               authorization_server_audience,
                    verify_sub:        true,
                    verify_expiration: true,


### PR DESCRIPTION
This is automatically creating an issuer that doesnt match the org okta issuer. Fixing it allowing to explicitly set the issuer string in the config